### PR TITLE
Update aeson upper version to latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ['8.6', '8.8', '8.10']
+        ghc: ['8.8', '8.10', '9.0.1']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ['8.8', '8.10', '9.0', '9.2', '9.4', 'latest']
+        ghc: ['8.8', '8.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ['8.8', '8.10']
+        ghc: ['8.8', '8.10', '9.0', '9.2', '9.4', 'latest']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ['8.8', '8.10', '9.0.1']
+        ghc: ['8.8', '8.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/rollbar-cli/package.yaml
+++ b/rollbar-cli/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-cli
-version: 0.1.0
+version: 0.2.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-cli/package.yaml
+++ b/rollbar-cli/package.yaml
@@ -33,7 +33,7 @@ library:
   source-dirs: src
   dependencies:
     - optparse-applicative >= 0.14 && < 1
-    - rollbar-client >= 0.1 && < 1
+    - rollbar-client >= 1.0 && < 2
 
 executables:
   rollbar:

--- a/rollbar-cli/package.yaml
+++ b/rollbar-cli/package.yaml
@@ -5,7 +5,7 @@ license: MIT
 author: "Stack Builders Inc."
 maintainer: "Sebastián Estrella <sestrella@stackbuilders.com>"
 copyright: "2020 Stack Builders Inc."
-tested-with: GHC ==8.6.5, GHC ==8.8.4, GHC ==8.10.2
+tested-with: GHC ==8.8.4, GHC ==8.10.2
 
 extra-source-files:
   - README.md

--- a/rollbar-cli/package.yaml
+++ b/rollbar-cli/package.yaml
@@ -22,7 +22,7 @@ ghc-options:
   - -Wall
 
 dependencies:
-  - base >= 4.12 && < 5
+  - base >= 4.13 && < 5
 
 _exe-ghc-options: &exe-ghc-options
   - -threaded

--- a/rollbar-cli/package.yaml
+++ b/rollbar-cli/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-cli
-version: 0.2.0
+version: 1.0.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-cli/rollbar-cli.cabal
+++ b/rollbar-cli/rollbar-cli.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: 550be30f2b0d05cb1448d3ac2048f42b360608d96c8bd70aa2815abe73fb9c08
 
 name:           rollbar-cli
-version:        0.1.0
+version:        0.2.0
 synopsis:       Simple CLI tool to perform commons tasks such as tracking deploys.
 description:    Please see the README on GitHub at
                 <https://github.com/stackbuilders/rollbar-haskell/tree/master/rollbar-cli>

--- a/rollbar-cli/rollbar-cli.cabal
+++ b/rollbar-cli/rollbar-cli.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: 550be30f2b0d05cb1448d3ac2048f42b360608d96c8bd70aa2815abe73fb9c08
 
 name:           rollbar-cli
-version:        0.2.0
+version:        1.0.0
 synopsis:       Simple CLI tool to perform commons tasks such as tracking deploys.
 description:    Please see the README on GitHub at
                 <https://github.com/stackbuilders/rollbar-haskell/tree/master/rollbar-cli>

--- a/rollbar-cli/rollbar-cli.cabal
+++ b/rollbar-cli/rollbar-cli.cabal
@@ -18,7 +18,7 @@ maintainer:     Sebastián Estrella <sestrella@stackbuilders.com>
 copyright:      2020 Stack Builders Inc.
 license:        MIT
 license-file:   LICENSE
-tested-with:    GHC ==8.6.5, GHC ==8.8.4, GHC ==8.10.2
+tested-with:    GHC ==8.8.4, GHC ==8.10.2
 build-type:     Simple
 extra-source-files:
     README.md

--- a/rollbar-cli/rollbar-cli.cabal
+++ b/rollbar-cli/rollbar-cli.cabal
@@ -37,7 +37,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      base >=4.12 && <5
+      base >=4.13 && <5
     , optparse-applicative >=0.14 && <1
     , rollbar-client >=0.1 && <1
   default-language: Haskell2010
@@ -50,7 +50,7 @@ executable rollbar
       app
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.12 && <5
+      base >=4.13 && <5
     , rollbar-cli
     , rollbar-client
   default-language: Haskell2010
@@ -64,6 +64,6 @@ test-suite spec
       test
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.12 && <5
+      base >=4.13 && <5
     , rollbar-cli
   default-language: Haskell2010

--- a/rollbar-cli/rollbar-cli.cabal
+++ b/rollbar-cli/rollbar-cli.cabal
@@ -39,7 +39,7 @@ library
   build-depends:
       base >=4.13 && <5
     , optparse-applicative >=0.14 && <1
-    , rollbar-client >=0.1 && <1
+    , rollbar-client >=1 && <2
   default-language: Haskell2010
 
 executable rollbar

--- a/rollbar-client/ChangeLog.md
+++ b/rollbar-client/ChangeLog.md
@@ -1,3 +1,14 @@
 # Changelog for rollbar-client
 
-## Unreleased changes
+All notable changes to this project will be documented in this file
+
+## [1.0.0] - 2022-12-28
+
+### Changed
+
+- Updated dependency aeson version.
+- Updated base version
+
+### Removed
+
+- Support for GHC 8.6.1

--- a/rollbar-client/package.yaml
+++ b/rollbar-client/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-client
-version: 0.1.0
+version: 0.2.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-client/package.yaml
+++ b/rollbar-client/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-client
-version: 0.2.0
+version: 1.0.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-client/package.yaml
+++ b/rollbar-client/package.yaml
@@ -22,7 +22,7 @@ ghc-options:
   - -Wall
 
 dependencies:
-  - base >= 4.12 && < 5
+  - base >= 4.13 && < 5
 
 flags:
   example:

--- a/rollbar-client/package.yaml
+++ b/rollbar-client/package.yaml
@@ -38,7 +38,7 @@ _exe-ghc-options: &exe-ghc-options
 library:
   source-dirs: src
   dependencies:
-    - aeson >= 2.0 && <= 2.2
+    - aeson >= 2.0 && <3
     - bytestring >= 0.10 && < 1
     - directory >= 1.3 && < 2
     - exceptions >= 0.10 && < 1

--- a/rollbar-client/package.yaml
+++ b/rollbar-client/package.yaml
@@ -5,7 +5,7 @@ license: MIT
 author: "Stack Builders Inc."
 maintainer: "Sebastián Estrella <sestrella@stackbuilders.com>"
 copyright: "2020 Stack Builders Inc."
-tested-with: GHC ==8.6.5, GHC ==8.8.4, GHC ==8.10.2
+tested-with: GHC ==8.8.4, GHC ==8.10.2
 
 extra-source-files:
   - README.md

--- a/rollbar-client/package.yaml
+++ b/rollbar-client/package.yaml
@@ -38,7 +38,7 @@ _exe-ghc-options: &exe-ghc-options
 library:
   source-dirs: src
   dependencies:
-    - aeson >= 1.4 && < 2
+    - aeson >= 1.4 && <= 2.2
     - bytestring >= 0.10 && < 1
     - directory >= 1.3 && < 2
     - exceptions >= 0.10 && < 1

--- a/rollbar-client/package.yaml
+++ b/rollbar-client/package.yaml
@@ -38,7 +38,7 @@ _exe-ghc-options: &exe-ghc-options
 library:
   source-dirs: src
   dependencies:
-    - aeson >= 1.4 && <= 2.2
+    - aeson >= 2.0 && <= 2.2
     - bytestring >= 0.10 && < 1
     - directory >= 1.3 && < 2
     - exceptions >= 0.10 && < 1

--- a/rollbar-client/rollbar-client.cabal
+++ b/rollbar-client/rollbar-client.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: b3e835bcc225cb66a06268126c5a04b48d06fd90b55677e26219ecfe207068d3
 
 name:           rollbar-client
-version:        0.2.0
+version:        1.0.0
 synopsis:       Core library to communicate with Rollbar API.
 description:    Please see the README on GitHub at
                 <https://github.com/stackbuilders/rollbar-haskell/tree/master/rollbar-client>

--- a/rollbar-client/rollbar-client.cabal
+++ b/rollbar-client/rollbar-client.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: b3e835bcc225cb66a06268126c5a04b48d06fd90b55677e26219ecfe207068d3
 
 name:           rollbar-client
-version:        0.1.0
+version:        0.2.0
 synopsis:       Core library to communicate with Rollbar API.
 description:    Please see the README on GitHub at
                 <https://github.com/stackbuilders/rollbar-haskell/tree/master/rollbar-client>

--- a/rollbar-client/rollbar-client.cabal
+++ b/rollbar-client/rollbar-client.cabal
@@ -47,7 +47,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      aeson >=2.0 && <=2.2
+      aeson >=2.0 && <3
     , base >=4.12 && <5
     , bytestring >=0.10 && <1
     , directory >=1.3 && <2

--- a/rollbar-client/rollbar-client.cabal
+++ b/rollbar-client/rollbar-client.cabal
@@ -48,7 +48,7 @@ library
   ghc-options: -Wall
   build-depends:
       aeson >=2.0 && <3
-    , base >=4.12 && <5
+    , base >=4.13 && <5
     , bytestring >=0.10 && <1
     , directory >=1.3 && <2
     , exceptions >=0.10 && <1
@@ -68,7 +68,7 @@ executable client-example
       example
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.12 && <5
+      base >=4.13 && <5
     , rollbar-client
     , text
   if flag(example)
@@ -90,7 +90,7 @@ test-suite spec
       hspec-discover:hspec-discover >=2.7 && <3
   build-depends:
       aeson
-    , base >=4.12 && <5
+    , base >=4.13 && <5
     , hspec >=2.7 && <3
     , mtl
     , rollbar-client

--- a/rollbar-client/rollbar-client.cabal
+++ b/rollbar-client/rollbar-client.cabal
@@ -18,7 +18,7 @@ maintainer:     Sebastián Estrella <sestrella@stackbuilders.com>
 copyright:      2020 Stack Builders Inc.
 license:        MIT
 license-file:   LICENSE
-tested-with:    GHC ==8.6.5, GHC ==8.8.4, GHC ==8.10.2
+tested-with:    GHC ==8.8.4, GHC ==8.10.2
 build-type:     Simple
 extra-source-files:
     README.md

--- a/rollbar-client/rollbar-client.cabal
+++ b/rollbar-client/rollbar-client.cabal
@@ -47,7 +47,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      aeson >=1.4 && <2
+      aeson >=1.4 && <=2.2
     , base >=4.12 && <5
     , bytestring >=0.10 && <1
     , directory >=1.3 && <2

--- a/rollbar-client/rollbar-client.cabal
+++ b/rollbar-client/rollbar-client.cabal
@@ -47,7 +47,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      aeson >=1.4 && <=2.2
+      aeson >=2.0 && <=2.2
     , base >=4.12 && <5
     , bytestring >=0.10 && <1
     , directory >=1.3 && <2

--- a/rollbar-client/src/Rollbar/Client/Item.hs
+++ b/rollbar-client/src/Rollbar/Client/Item.hs
@@ -361,7 +361,7 @@ instance ToJSON Notifier where
 defaultNotifier :: Notifier
 defaultNotifier = Notifier
   { notifierName = "rollbar-client"
-  , notifierVersion = "0.2.0"
+  , notifierVersion = "1.0.0"
   }
 
 newtype ItemId = ItemId Text

--- a/rollbar-client/src/Rollbar/Client/Item.hs
+++ b/rollbar-client/src/Rollbar/Client/Item.hs
@@ -361,7 +361,7 @@ instance ToJSON Notifier where
 defaultNotifier :: Notifier
 defaultNotifier = Notifier
   { notifierName = "rollbar-client"
-  , notifierVersion = "0.1.0"
+  , notifierVersion = "0.2.0"
   }
 
 newtype ItemId = ItemId Text

--- a/rollbar-client/test/Rollbar/ClientSpec.hs
+++ b/rollbar-client/test/Rollbar/ClientSpec.hs
@@ -7,7 +7,7 @@ module Rollbar.ClientSpec
   ( spec
   ) where
 
-import qualified Data.HashMap.Strict as HM
+import qualified Data.Aeson.KeyMap as KM
 
 import Control.Monad.Reader
 import Data.Aeson
@@ -41,11 +41,11 @@ spec = do
         request = Request
           { requestUrl = "http://example.com"
           , requestMethod = "GET"
-          , requestHeaders = HM.fromList
+          , requestHeaders = KM.fromList
               [ ("Host", "example.com")
               , ("Secret", "p4ssw0rd")
               ]
-          , requestParams = HM.fromList
+          , requestParams = KM.fromList
               [ ("user", "John Doe")
               , ("password", "p4ssw0rd")
               ]
@@ -61,28 +61,28 @@ spec = do
             defaultRequestModifiers
               { requestModifiersExcludeHeaders = Just $ pure "Secret" }
       in requestModifier request `shouldBe` request
-           { requestHeaders = HM.fromList [("Host", "example.com")] }
+           { requestHeaders = KM.fromList [("Host", "example.com")] }
 
     it "excludes the params not matching the given names" $
       let requestModifier = runReader getRequestModifier $ mkSettings $
             defaultRequestModifiers
               { requestModifiersExcludeParams = Just $ pure "password" }
       in requestModifier request `shouldBe` request
-           { requestParams = HM.fromList [("user", "John Doe")] }
+           { requestParams = KM.fromList [("user", "John Doe")] }
 
     it "includes only the headers matching the given names" $
       let requestModifier = runReader getRequestModifier $ mkSettings $
             defaultRequestModifiers
               { requestModifiersIncludeHeaders = Just $ pure "Host" }
       in requestModifier request `shouldBe` request
-           { requestHeaders = HM.fromList [("Host", "example.com")] }
+           { requestHeaders = KM.fromList [("Host", "example.com")] }
 
     it "includes only the params matching the given names" $
       let requestModifier = runReader getRequestModifier $ mkSettings $
             defaultRequestModifiers
               { requestModifiersIncludeParams = Just $ pure "user" }
       in requestModifier request `shouldBe` request
-           { requestParams = HM.fromList [("user", "John Doe")] }
+           { requestParams = KM.fromList [("user", "John Doe")] }
 
   describe "defaultNotifier" $
     it "matches the package name and version" $ do
@@ -127,7 +127,7 @@ spec = do
           itemId <- runRollbar settings $ do
             item <- mkItem $ PayloadMessage $ Message
               { messageBody = "Request over threshold of 10 seconds"
-              , messageMetadata = HM.fromList
+              , messageMetadata = KM.fromList
                   [ ("route", "home#index")
                   , ("time_elapsed", Number 15.23)
                   ]

--- a/rollbar-wai/package.yaml
+++ b/rollbar-wai/package.yaml
@@ -24,7 +24,7 @@ ghc-options:
   - -Wall
 
 dependencies:
-  - base >= 4.12 && < 5
+  - base >= 4.13 && < 5
 
 flags:
   example:

--- a/rollbar-wai/package.yaml
+++ b/rollbar-wai/package.yaml
@@ -44,7 +44,7 @@ library:
     - bytestring >= 0.10 && < 1
     - case-insensitive >= 1.2 && < 2
     - http-types >= 0.12 && < 1
-    - rollbar-client >= 0.1 && < 1
+    - rollbar-client >= 1.0 && < 2
     - text >= 1.2 && < 2
     - unordered-containers >= 0.2 && < 1
     - wai >= 3.2 && < 4

--- a/rollbar-wai/package.yaml
+++ b/rollbar-wai/package.yaml
@@ -40,7 +40,7 @@ _exe-ghc-options: &exe-ghc-options
 library:
   source-dirs: src
   dependencies:
-    - aeson >= 2.0 && <= 2.2
+    - aeson >= 2.0 && <3
     - bytestring >= 0.10 && < 1
     - case-insensitive >= 1.2 && < 2
     - http-types >= 0.12 && < 1

--- a/rollbar-wai/package.yaml
+++ b/rollbar-wai/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-wai
-version: 0.1.0
+version: 0.2.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-wai/package.yaml
+++ b/rollbar-wai/package.yaml
@@ -40,7 +40,7 @@ _exe-ghc-options: &exe-ghc-options
 library:
   source-dirs: src
   dependencies:
-    - aeson >= 1.4 && <= 2.2
+    - aeson >= 2.0 && <= 2.2
     - bytestring >= 0.10 && < 1
     - case-insensitive >= 1.2 && < 2
     - http-types >= 0.12 && < 1

--- a/rollbar-wai/package.yaml
+++ b/rollbar-wai/package.yaml
@@ -5,7 +5,7 @@ license: MIT
 author: "Stack Builders Inc."
 maintainer: "Sebastián Estrella <sestrella@stackbuilders.com>"
 copyright: "2020 Stack Builders Inc."
-tested-with: GHC ==8.6.5, GHC ==8.8.4, GHC ==8.10.2
+tested-with: GHC ==8.8.4, GHC ==8.10.2
 
 extra-source-files:
   - README.md

--- a/rollbar-wai/package.yaml
+++ b/rollbar-wai/package.yaml
@@ -40,7 +40,7 @@ _exe-ghc-options: &exe-ghc-options
 library:
   source-dirs: src
   dependencies:
-    - aeson >= 1.4 && < 2
+    - aeson >= 1.4 && <= 2.2
     - bytestring >= 0.10 && < 1
     - case-insensitive >= 1.2 && < 2
     - http-types >= 0.12 && < 1

--- a/rollbar-wai/package.yaml
+++ b/rollbar-wai/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-wai
-version: 0.2.0
+version: 1.0.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-wai/rollbar-wai.cabal
+++ b/rollbar-wai/rollbar-wai.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: 36882de3e15bbc25fa5b54c1ee7d9dbe96436e87f4502b002a3a388508677741
 
 name:           rollbar-wai
-version:        0.2.0
+version:        1.0.0
 synopsis:       Provides error reporting capabilities to WAI based applications through Rollbar API.
 
 description:    Please see the README on GitHub at

--- a/rollbar-wai/rollbar-wai.cabal
+++ b/rollbar-wai/rollbar-wai.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: 36882de3e15bbc25fa5b54c1ee7d9dbe96436e87f4502b002a3a388508677741
 
 name:           rollbar-wai
-version:        0.1.0
+version:        0.2.0
 synopsis:       Provides error reporting capabilities to WAI based applications through Rollbar API.
 
 description:    Please see the README on GitHub at

--- a/rollbar-wai/rollbar-wai.cabal
+++ b/rollbar-wai/rollbar-wai.cabal
@@ -19,7 +19,7 @@ maintainer:     Sebastián Estrella <sestrella@stackbuilders.com>
 copyright:      2020 Stack Builders Inc.
 license:        MIT
 license-file:   LICENSE
-tested-with:    GHC ==8.6.5, GHC ==8.8.4, GHC ==8.10.2
+tested-with:    GHC ==8.8.4, GHC ==8.10.2
 build-type:     Simple
 extra-source-files:
     README.md

--- a/rollbar-wai/rollbar-wai.cabal
+++ b/rollbar-wai/rollbar-wai.cabal
@@ -48,7 +48,7 @@ library
     , bytestring >=0.10 && <1
     , case-insensitive >=1.2 && <2
     , http-types >=0.12 && <1
-    , rollbar-client >=0.1 && <1
+    , rollbar-client >=1.0 && <2
     , text >=1.2 && <2
     , unordered-containers >=0.2 && <1
     , wai >=3.2 && <4

--- a/rollbar-wai/rollbar-wai.cabal
+++ b/rollbar-wai/rollbar-wai.cabal
@@ -44,7 +44,7 @@ library
   ghc-options: -Wall
   build-depends:
       aeson >=2.0 && <3
-    , base >=4.12 && <5
+    , base >=4.13 && <5
     , bytestring >=0.10 && <1
     , case-insensitive >=1.2 && <2
     , http-types >=0.12 && <1
@@ -63,7 +63,7 @@ executable wai-example
       example
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.12 && <5
+      base >=4.13 && <5
     , rollbar-client
     , rollbar-wai
     , wai
@@ -87,7 +87,7 @@ test-suite spec
       hspec-discover:hspec-discover >=2.7 && <3
   build-depends:
       aeson
-    , base >=4.12 && <5
+    , base >=4.13 && <5
     , hspec >=2.7 && <3
     , http-types
     , mtl >=2.2 && <3

--- a/rollbar-wai/rollbar-wai.cabal
+++ b/rollbar-wai/rollbar-wai.cabal
@@ -43,7 +43,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      aeson >=2.0 && <=2.2
+      aeson >=2.0 && <3
     , base >=4.12 && <5
     , bytestring >=0.10 && <1
     , case-insensitive >=1.2 && <2

--- a/rollbar-wai/rollbar-wai.cabal
+++ b/rollbar-wai/rollbar-wai.cabal
@@ -43,7 +43,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      aeson >=1.4 && <2
+      aeson >=1.4 && <=2.2
     , base >=4.12 && <5
     , bytestring >=0.10 && <1
     , case-insensitive >=1.2 && <2

--- a/rollbar-wai/rollbar-wai.cabal
+++ b/rollbar-wai/rollbar-wai.cabal
@@ -43,7 +43,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      aeson >=1.4 && <=2.2
+      aeson >=2.0 && <=2.2
     , base >=4.12 && <5
     , bytestring >=0.10 && <1
     , case-insensitive >=1.2 && <2

--- a/rollbar-wai/src/Rollbar/Wai.hs
+++ b/rollbar-wai/src/Rollbar/Wai.hs
@@ -16,7 +16,8 @@ module Rollbar.Wai
   ) where
 
 import qualified Data.CaseInsensitive as CI
-import qualified Data.HashMap.Strict as HM
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.Aeson.Key as K
 import qualified Data.Text.Encoding as T
 import qualified Network.Wai as W
 import qualified Network.Wai.Parse as W
@@ -27,6 +28,7 @@ import Control.Exception
 import Control.Monad (void)
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Aeson
+import Data.Bifunctor (first)
 import Network.HTTP.Types (renderQuery)
 import Rollbar.Client
 
@@ -83,11 +85,11 @@ mkRequest req = liftIO $ do
         , W.rawQueryString req
         ]
     , requestMethod = T.decodeUtf8 $ W.requestMethod req
-    , requestHeaders = HM.fromList $ toHeader <$> W.requestHeaders req
+    , requestHeaders = KM.fromList $ map (first K.fromText) $ toHeader <$> W.requestHeaders req
     , requestParams = mempty
-    , requestGet = HM.fromList $ toQuery <$> W.queryString req
+    , requestGet = KM.fromList $ map (first K.fromText) $ toQuery <$> W.queryString req
     , requestQueryStrings = T.decodeUtf8 $ renderQuery False $ W.queryString req
-    , requestPost = HM.fromList $ fmap toParam params
+    , requestPost = KM.fromList $ map (first K.fromText) $ fmap toParam params
     , requestBody = ""
     , requestUserIp = ""
     }

--- a/rollbar-wai/test/Rollbar/WaiSpec.hs
+++ b/rollbar-wai/test/Rollbar/WaiSpec.hs
@@ -5,7 +5,7 @@ module Rollbar.WaiSpec
   ( spec
   ) where
 
-import qualified Data.HashMap.Strict as HM
+import qualified Data.Aeson.KeyMap as KM
 import qualified Data.Text as T
 import qualified Network.Wai as W
 import qualified Network.Wai.Handler.Warp as W
@@ -50,7 +50,7 @@ spec = before getSettingsAndItemRef $
             ( Request
                 { requestUrl = "http://localhost:" <> portAsText <> "/error"
                 , requestMethod = "GET"
-                , requestHeaders = HM.fromList
+                , requestHeaders = KM.fromList
                     [ ("Accept-Encoding", "gzip")
                     , ("Host", String $ "localhost:" <> portAsText)
                     ]

--- a/rollbar-yesod/package.yaml
+++ b/rollbar-yesod/package.yaml
@@ -41,8 +41,8 @@ _exe-ghc-options: &exe-ghc-options
 library:
   source-dirs: src
   dependencies:
-    - rollbar-client >= 0.1 && < 1
-    - rollbar-wai >= 0.1 && < 1
+    - rollbar-client >= 1.0 && < 2
+    - rollbar-wai >= 1.0 && < 2
     - unliftio >= 0.2 && < 1
     - wai >= 3.2 && < 4
     - yesod-core >= 1.6 && < 2

--- a/rollbar-yesod/package.yaml
+++ b/rollbar-yesod/package.yaml
@@ -25,7 +25,7 @@ ghc-options:
   - -Wall
 
 dependencies:
-  - base >= 4.12 && < 5
+  - base >= 4.13 && < 5
 
 flags:
   example:

--- a/rollbar-yesod/package.yaml
+++ b/rollbar-yesod/package.yaml
@@ -5,7 +5,7 @@ license: MIT
 author: "Stack Builders Inc."
 maintainer: "Sebastián Estrella <sestrella@stackbuilders.com>"
 copyright: "2020 Stack Builders Inc."
-tested-with: GHC ==8.6.5, GHC ==8.8.4, GHC ==8.10.2
+tested-with: GHC ==8.8.4, GHC ==8.10.2
 
 extra-source-files:
   - README.md

--- a/rollbar-yesod/package.yaml
+++ b/rollbar-yesod/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-yesod
-version: 0.2.0
+version: 1.0.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-yesod/package.yaml
+++ b/rollbar-yesod/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-yesod
-version: 0.1.0
+version: 0.2.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-yesod/rollbar-yesod.cabal
+++ b/rollbar-yesod/rollbar-yesod.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: d007a8f11fac3e9745d78838751cf81ae9ce6f553d2a8e7f8aad77b97ad6d903
 
 name:           rollbar-yesod
-version:        0.1.0
+version:        0.2.0
 synopsis:       Provides error reporting capabilities to Yesod applications through Rollbar API.
 
 description:    Please see the README on GitHub at

--- a/rollbar-yesod/rollbar-yesod.cabal
+++ b/rollbar-yesod/rollbar-yesod.cabal
@@ -19,7 +19,7 @@ maintainer:     Sebastián Estrella <sestrella@stackbuilders.com>
 copyright:      2020 Stack Builders Inc.
 license:        MIT
 license-file:   LICENSE
-tested-with:    GHC ==8.6.5, GHC ==8.8.4, GHC ==8.10.2
+tested-with:    GHC ==8.8.4, GHC ==8.10.2
 build-type:     Simple
 extra-source-files:
     README.md

--- a/rollbar-yesod/rollbar-yesod.cabal
+++ b/rollbar-yesod/rollbar-yesod.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: d007a8f11fac3e9745d78838751cf81ae9ce6f553d2a8e7f8aad77b97ad6d903
 
 name:           rollbar-yesod
-version:        0.2.0
+version:        1.0.0
 synopsis:       Provides error reporting capabilities to Yesod applications through Rollbar API.
 
 description:    Please see the README on GitHub at

--- a/rollbar-yesod/rollbar-yesod.cabal
+++ b/rollbar-yesod/rollbar-yesod.cabal
@@ -43,7 +43,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      base >=4.12 && <5
+      base >=4.13 && <5
     , rollbar-client >=0.1 && <1
     , rollbar-wai >=0.1 && <1
     , unliftio >=0.2 && <1
@@ -59,7 +59,7 @@ executable yesod-example
       example
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.12 && <5
+      base >=4.13 && <5
     , rollbar-client
     , rollbar-yesod
     , warp >=3.3 && <4
@@ -82,7 +82,7 @@ test-suite spec
   build-tool-depends:
       hspec-discover:hspec-discover >=2.7 && <3
   build-depends:
-      base >=4.12 && <5
+      base >=4.13 && <5
     , hspec >=2.7 && <3
     , rollbar-client
     , rollbar-yesod

--- a/rollbar-yesod/rollbar-yesod.cabal
+++ b/rollbar-yesod/rollbar-yesod.cabal
@@ -44,8 +44,8 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.13 && <5
-    , rollbar-client >=0.1 && <1
-    , rollbar-wai >=0.1 && <1
+    , rollbar-client >=1.0 && <2
+    , rollbar-wai >=1.0 && <2
     , unliftio >=0.2 && <1
     , wai >=3.2 && <4
     , yesod-core >=1.6 && <2


### PR DESCRIPTION
This change changes the upper bound of the aeson dependency so it nows accepts the latest  version of aeson. In the latest versions of Aeson, a special key map is used.