### PR TITLE
correct documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ env ROLLBAR_TOKEN=<token> stack test
 
 [MIT](LICENSE)
 
-[rollbar-api]: https://explorer.docs.rollbar.com/
+[rollbar-api]: https://docs.rollbar.com/


### PR DESCRIPTION
explorer.docs.rollbar.com doesn't exist anymore.