### PR TITLE
Add fields fingerprint, title, uuid, custom

### DIFF
--- a/rollbar-client/src/Rollbar/Client/Item.hs
+++ b/rollbar-client/src/Rollbar/Client/Item.hs
@@ -80,10 +80,14 @@ data Item = Item
   , itemServer :: Maybe Server
     -- ^ Data about the server related to this event.
   -- client
-  -- custom
-  -- fingerprint
-  -- title
-  -- uuid
+  , custom :: Maybe Object
+    -- ^ Any arbitrary metadata you want to send.
+  , title :: Maybe Text
+    -- ^ A string that will be used as the title of the Item occurrences will be grouped into.
+  , uuid :: Maybe Text
+    -- ^ Identifies this occurrence.
+  , fingerprint :: Maybe Text
+    -- ^ Controlls how this occurrence should be grouped.
   , itemNotifier :: Notifier
     -- ^ Describes the library used to send this event.
   } deriving (Eq, Show)
@@ -100,6 +104,10 @@ instance ToJSON Item where
         , "request" .= itemRequest
         , "server" .= itemServer
         , "notifier" .= itemNotifier
+        , "fingerprint" .= fingerprint
+        , "title" .= title
+        , "uuid" .= uuid
+        , "custom" .= custom
         ]
     ]
 


### PR DESCRIPTION
Hi we are attempting to migrate to this library from https://github.com/joneshf/rollbar-hs however there are a few fields missing. I've added them.

I could use some help with building this project. I tried the cabal instructions in the readme and got the following
```
cabal build all
Resolving dependencies...
Error: cabal: Could not resolve dependencies:
[__0] trying: rollbar-cli-1.0.0 (user goal)
[__1] trying: base-4.18.0.0/installed-4.18.0.0 (dependency of rollbar-cli)
[__2] trying: rollbar-client-1.0.0 (user goal)
[__3] next goal: text (dependency of rollbar-client)
[__3] rejecting: text-2.0.2/installed-2.0.2 (conflict: rollbar-client =>
text>=1.2 && <2)
[__3] skipping: text-2.1, text-2.0.2, text-2.0.1, text-2.0 (has the same
characteristics that caused the previous version to fail: excluded by
constraint '>=1.2 && <2' from 'rollbar-client')
[__3] rejecting: text-1.2.5.0 (conflict: base =>
ghc-prim==0.10.0/installed-0.10.0, text => ghc-prim>=0.2 && <0.9)
[__3] rejecting: text-1.2.4.1 (conflict: base==4.18.0.0/installed-4.18.0.0,
text => base>=4.3 && <4.16)
[__3] rejecting: text-1.2.4.0 (conflict: base =>
ghc-prim==0.10.0/installed-0.10.0, text => ghc-prim>=0.2 && <0.6)
[__3] rejecting: text-1.2.3.2 (conflict: base==4.18.0.0/installed-4.18.0.0,
text => base>=4.14 && <4.15)
[__3] skipping: text-1.2.3.1, text-1.2.3.0, text-1.2.2.2, text-1.2.2.1,
text-1.2.2.0, text-1.2.1.3, text-1.2.1.2, text-1.2.1.1, text-1.2.1.0,
text-1.2.0.6, text-1.2.0.5, text-1.2.0.4, text-1.2.0.3, text-1.2.0.2,
text-1.2.0.0 (has the same characteristics that caused the previous version to
fail: excludes 'base' version 4.18.0.0)
[__3] rejecting: text-1.1.1.4 (conflict: rollbar-client => text>=1.2 && <2)
[__3] skipping: text-1.1.1.3, text-1.1.1.2, text-1.1.1.1, text-1.1.1.0,
text-1.1.0.1, text-1.1.0.0, text-1.0.0.1, text-1.0.0.0, text-0.11.3.1,
text-0.11.3.0, text-0.11.2.3, text-0.11.2.2, text-0.11.2.1, text-0.11.2.0,
text-0.11.1.13, text-0.11.1.12, text-0.11.1.11, text-0.11.1.10, text-0.11.1.9,
text-0.11.1.8, text-0.11.1.7, text-0.11.1.6, text-0.11.1.5, text-0.11.1.3,
text-0.11.1.2, text-0.11.1.1, text-0.11.1.0, text-0.11.0.8, text-0.11.0.7,
text-0.11.0.6, text-0.11.0.5, text-0.11.0.4, text-0.11.0.3, text-0.11.0.2,
text-0.11.0.1, text-0.11.0.0, text-0.10.0.2, text-0.10.0.1, text-0.10.0.0,
text-0.9.1.0, text-0.9.0.1, text-0.9.0.0, text-0.8.1.0, text-0.8.0.0,
text-0.7.2.1, text-0.7.1.0, text-0.7.0.1, text-0.7, text-0.6, text-0.5,
text-0.4, text-0.3, text-0.2, text-0.1 (has the same characteristics that
caused the previous version to fail: excluded by constraint '>=1.2 && <2' from
'rollbar-client')
[__3] fail (backjumping, conflict set: base, rollbar-client, text)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: text, base, rollbar-client,
rollbar-cli
Try running with --minimize-conflict-set to improve the error message.
```

I'm open to using nix if that might be easier to use, and if someone could tell me what commands to run after installing it. Thanks!