### PR TITLE
Add PR trigger to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,9 @@
 
 name: CI
 
-on: push
+on: 
+  pull_request:
+  push:
 
 concurrency:
   group: build-${{ github.ref }}


### PR DESCRIPTION
Currently, the CI does not get triggered in PRs from outside contributors (i.e. coming from forks). We want to allow that (the PRs will still require maintainer's approval for new contributors, but at least we can run the CI in PRs coming from forks.

This PR adds a trigger to the GitHub Actions workflow so that the CI can run in PRs coming from forks.