### PR TITLE
Added GHC 9.4 to CI build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       matrix:
         ghc-version: 
+          - '8.8'
           - '8.10' 
           - '9.4'
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-version: ['8.10', '8.8']
+        ghc-version: ['8.10', '9.4.7']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-version: ['8.10', '9.4.7']
+        ghc-version: 
+          - '8.10' 
+          - '9.4'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/rollbar-cli/package.yaml
+++ b/rollbar-cli/package.yaml
@@ -5,7 +5,7 @@ license: MIT
 author: "Stack Builders Inc."
 maintainer: "David Mazarro <dmunuera@stackbuilders.com>"
 copyright: "2020-present Stack Builders Inc."
-tested-with: GHC ==8.8.4, GHC ==8.10.2
+tested-with: GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 
 extra-source-files:
   - README.md

--- a/rollbar-cli/rollbar-cli.cabal
+++ b/rollbar-cli/rollbar-cli.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c07bf1af31c5b866267fc85ec670e4af1162374603593d10d1d509c0fb6dbc92
+-- hash: 7c6698b375ec164c76d2431962f34299163ec2755d348dc931999d649f19669e
 
 name:           rollbar-cli
 version:        1.0.0
@@ -20,7 +20,7 @@ copyright:      2020-present Stack Builders Inc.
 license:        MIT
 license-file:   LICENSE
 tested-with:
-    GHC ==8.8.4, GHC ==8.10.2
+    GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 build-type:     Simple
 extra-source-files:
     README.md

--- a/rollbar-client/package.yaml
+++ b/rollbar-client/package.yaml
@@ -5,7 +5,7 @@ license: MIT
 author: "Stack Builders Inc."
 maintainer: "David Mazarro <dmunuera@stackbuilders.com>"
 copyright: "2020-present Stack Builders Inc."
-tested-with: GHC ==8.8.4, GHC ==8.10.2
+tested-with: GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 
 extra-source-files:
   - README.md
@@ -45,7 +45,7 @@ library:
     - mtl >= 2.2 && < 3
     - process >= 1.6 && < 2
     - req >= 2.1 && < 4
-    - text >= 1.2 && < 2
+    - text >= 1.2 && < 2.1
     - unordered-containers >= 0.2 && < 1
     - yaml >= 0.11 && < 1
   exposed-modules:

--- a/rollbar-client/rollbar-client.cabal
+++ b/rollbar-client/rollbar-client.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7da5a5954a90f46d394e2473225be065b9af60f16debf983e5f517d50dd7dce7
+-- hash: 00c54f5f1b124b9d08c5cbe143b9aef68916a289a7a63068ae10e692a1524f91
 
 name:           rollbar-client
 version:        1.0.0
@@ -20,7 +20,7 @@ copyright:      2020-present Stack Builders Inc.
 license:        MIT
 license-file:   LICENSE
 tested-with:
-    GHC ==8.8.4, GHC ==8.10.2
+    GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 build-type:     Simple
 extra-source-files:
     README.md
@@ -73,11 +73,11 @@ executable client-example
       base >=4.13 && <5
     , rollbar-client
     , text
+  default-language: Haskell2010
   if flag(example)
     buildable: True
   else
     buildable: False
-  default-language: Haskell2010
 
 test-suite spec
   type: exitcode-stdio-1.0

--- a/rollbar-wai/package.yaml
+++ b/rollbar-wai/package.yaml
@@ -5,7 +5,7 @@ license: MIT
 author: "Stack Builders Inc."
 maintainer: "David Mazarro <dmunuera@stackbuilders.com>"
 copyright: "2020-present Stack Builders Inc."
-tested-with: GHC ==8.8.4, GHC ==8.10.2
+tested-with: GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 
 extra-source-files:
   - README.md
@@ -45,7 +45,7 @@ library:
     - case-insensitive >= 1.2 && < 2
     - http-types >= 0.12 && < 1
     - rollbar-client >= 1.0 && < 2
-    - text >= 1.2 && < 2
+    - text >= 1.2 && < 2.1
     - unordered-containers >= 0.2 && < 1
     - wai >= 3.2 && < 4
     - wai-extra >= 3.0 && < 4

--- a/rollbar-wai/rollbar-wai.cabal
+++ b/rollbar-wai/rollbar-wai.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 22fc7c0ac87561c87ece5a7fc5e7488798240e33a8e5f664ddb1359452f6e042
+-- hash: b1784f3e45d1f870ae1ea4567c427a2eb4605d9103bde27be65e2ab8698e74ba
 
 name:           rollbar-wai
 version:        1.0.0
@@ -21,7 +21,7 @@ copyright:      2020-present Stack Builders Inc.
 license:        MIT
 license-file:   LICENSE
 tested-with:
-    GHC ==8.8.4, GHC ==8.10.2
+    GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 build-type:     Simple
 extra-source-files:
     README.md
@@ -70,11 +70,11 @@ executable wai-example
     , rollbar-wai
     , wai
     , warp
+  default-language: Haskell2010
   if flag(example)
     buildable: True
   else
     buildable: False
-  default-language: Haskell2010
 
 test-suite spec
   type: exitcode-stdio-1.0

--- a/rollbar-yesod/package.yaml
+++ b/rollbar-yesod/package.yaml
@@ -5,7 +5,7 @@ license: MIT
 author: "Stack Builders Inc."
 maintainer: "David Mazarro <dmunuera@stackbuilders.com>"
 copyright: "2020-present Stack Builders Inc."
-tested-with: GHC ==8.8.4, GHC ==8.10.2
+tested-with: GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 
 extra-source-files:
   - README.md

--- a/rollbar-yesod/rollbar-yesod.cabal
+++ b/rollbar-yesod/rollbar-yesod.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 07ec6f4e4497c06c6b37555f1514fdd3b8751a689ac2dc6e254a71a79879a00e
+-- hash: 928697afe6fc01901eb1e55e4cf239102c43949165f2e912442b44fc521a3dfb
 
 name:           rollbar-yesod
 version:        1.0.0
@@ -21,7 +21,7 @@ copyright:      2020-present Stack Builders Inc.
 license:        MIT
 license-file:   LICENSE
 tested-with:
-    GHC ==8.8.4, GHC ==8.10.2
+    GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 build-type:     Simple
 extra-source-files:
     README.md
@@ -66,11 +66,11 @@ executable yesod-example
     , rollbar-yesod
     , warp >=3.3 && <4
     , yesod-core
+  default-language: Haskell2010
   if flag(example)
     buildable: True
   else
     buildable: False
-  default-language: Haskell2010
 
 test-suite spec
   type: exitcode-stdio-1.0


### PR DESCRIPTION
Since we should support recent versions of GHC, I have added GHC 9.4 to the CI build matrix. GHC 9.4.7 is the current recommended GHC 9 version by [GHCup](https://www.haskell.org/ghcup/).

Closes #56.