### PR TITLE
Added `kleidukos/get-tested` action to generate CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,14 +18,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  generate-matrix:
+    name: "Generate matrix from cabal"
+    outputs: 
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-latest
+    steps:
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        uses: kleidukos/get-tested@v0.1.6.0
+        with:
+          cabal-file: rollbar-client/rollbar-client.cabal
+          ubuntu: true
+          version: 0.1.6.0
+  build:
+    name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
+    needs: generate-matrix
+    runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        ghc-version: 
-          - '8.8'
-          - '8.10' 
-          - '9.4'
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: ${{ matrix.ghc-version }}
+          ghc-version: ${{ matrix.ghc }}
           cabal-version: 'latest'
           cabal-update: true
       - name: Configure the build


### PR DESCRIPTION
Thanks to the [get-tested](https://github.com/Kleidukos/get-tested) action, we can automatically generate the matrix of GHC versions to run the CI on. This keeps the `tested-with` versions we set in Cabal files accurate to what is actually being tested in the CI.

Since the action takes one Cabal file as reference, I pointed it to `rollbar-client.cabal` since that is the main library in this repository. In any case, us maintainers need to keep all of the `tested-with` versions in sync across the four Haskell packages we offer in this repository.