### PR TITLE
Updating CI to new get-tested version (v0.1.7.0)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,11 +26,12 @@ jobs:
     steps:
       - name: Extract the tested GHC versions
         id: set-matrix
-        uses: kleidukos/get-tested@v0.1.6.0
+        uses: kleidukos/get-tested@v0.1.7.0
         with:
           cabal-file: rollbar-client/rollbar-client.cabal
-          ubuntu: true
-          version: 0.1.6.0
+          ubuntu-version: latest
+          macos-version: latest
+          version: 0.1.7.0
   build:
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
     needs: generate-matrix


### PR DESCRIPTION
I opened this issue https://github.com/Kleidukos/get-tested/issues/32 in the `get-tested` repo with a feature request to support setting the specific version of the OS runner we want to run; prior to the v0.1.7.0 version, the runners were all set to `*-latest`. Thanks to @Kleidukos' work, this is now supported in the most recent v0.1.7.0 version of `get-tested`. This PR changes our workflow to this new version of the action.