### PR TITLE
build: Upgrading version from 1.0.0 to 1.1.0

### DIFF
--- a/rollbar-cli/ChangeLog.md
+++ b/rollbar-cli/ChangeLog.md
@@ -1,3 +1,13 @@
 # Changelog for rollbar-cli
 
+All notable changes to this project will be documented in this file.
+
+## [1.1.0] - 2024-05-28
+
+### Changed
+- Added support for GHC 9.4.7
+
+### Removed
+- Support for GHC 8.10.2 (in favor of GHC 8.10.7)
+
 ## Unreleased changes

--- a/rollbar-cli/package.yaml
+++ b/rollbar-cli/package.yaml
@@ -9,7 +9,7 @@ tested-with: GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 
 extra-source-files:
   - README.md
-  - CHANGELOG.md
+  - ChangeLog.md
 
 synopsis: Simple CLI tool to perform commons tasks such as tracking deploys.
 category: Network

--- a/rollbar-cli/package.yaml
+++ b/rollbar-cli/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-cli
-version: 1.0.0
+version: 1.1.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-cli/package.yaml
+++ b/rollbar-cli/package.yaml
@@ -9,7 +9,7 @@ tested-with: GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 
 extra-source-files:
   - README.md
-  - ChangeLog.md
+  - CHANGELOG.md
 
 synopsis: Simple CLI tool to perform commons tasks such as tracking deploys.
 category: Network

--- a/rollbar-cli/rollbar-cli.cabal
+++ b/rollbar-cli/rollbar-cli.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ae5168319725bb8831213aeb96007f55cae084aed5fa10fd11a30937a136dabd
+-- hash: 2b5a59db1787ffd90341f1b10e9523d4cace1370610cd5e3a7b823f811be305d
 
 name:           rollbar-cli
-version:        1.0.0
+version:        1.1.0
 synopsis:       Simple CLI tool to perform commons tasks such as tracking deploys.
 description:    Please see the README on GitHub at
                 <https://github.com/stackbuilders/rollbar-haskell/tree/master/rollbar-cli>

--- a/rollbar-cli/rollbar-cli.cabal
+++ b/rollbar-cli/rollbar-cli.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7c6698b375ec164c76d2431962f34299163ec2755d348dc931999d649f19669e
+-- hash: ae5168319725bb8831213aeb96007f55cae084aed5fa10fd11a30937a136dabd
 
 name:           rollbar-cli
 version:        1.0.0
@@ -24,7 +24,7 @@ tested-with:
 build-type:     Simple
 extra-source-files:
     README.md
-    ChangeLog.md
+    CHANGELOG.md
 
 source-repository head
   type: git

--- a/rollbar-cli/rollbar-cli.cabal
+++ b/rollbar-cli/rollbar-cli.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2b5a59db1787ffd90341f1b10e9523d4cace1370610cd5e3a7b823f811be305d
+-- hash: 99c3aa74e5ef6c059b7ebeb837bca8f09c047df2a00b6856c99a919e4ad041ed
 
 name:           rollbar-cli
 version:        1.1.0
@@ -24,7 +24,7 @@ tested-with:
 build-type:     Simple
 extra-source-files:
     README.md
-    CHANGELOG.md
+    ChangeLog.md
 
 source-repository head
   type: git

--- a/rollbar-client/ChangeLog.md
+++ b/rollbar-client/ChangeLog.md
@@ -1,6 +1,16 @@
 # Changelog for rollbar-client
 
-All notable changes to this project will be documented in this file
+All notable changes to this project will be documented in this file.
+
+## [1.1.0] - 2024-05-28
+
+### Changed
+- Added fields fingerprint, title, uuid, custom to `Item`
+- Added support for GHC 9.4.7
+- Changed `text` dependency upper bound: we now support `text-2.0.X.X`.
+
+### Removed
+- Support for GHC 8.10.2 (in favor of GHC 8.10.7)
 
 ## [1.0.0] - 2022-12-28
 

--- a/rollbar-client/package.yaml
+++ b/rollbar-client/package.yaml
@@ -9,7 +9,7 @@ tested-with: GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 
 extra-source-files:
   - README.md
-  - CHANGELOG.md
+  - ChangeLog.md
 
 synopsis: Core library to communicate with Rollbar API.
 category: Network

--- a/rollbar-client/package.yaml
+++ b/rollbar-client/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-client
-version: 1.0.0
+version: 1.1.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-client/package.yaml
+++ b/rollbar-client/package.yaml
@@ -9,7 +9,7 @@ tested-with: GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 
 extra-source-files:
   - README.md
-  - ChangeLog.md
+  - CHANGELOG.md
 
 synopsis: Core library to communicate with Rollbar API.
 category: Network

--- a/rollbar-client/rollbar-client.cabal
+++ b/rollbar-client/rollbar-client.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1931cea8ad6754d11a0a9999cf3bd306f24d3b9b492d2bd442edbd99b1f1a78d
+-- hash: 81d6afa5ec6b2f06fd39127d2ad1f8ad60dc296787ba7008b4850224495641fe
 
 name:           rollbar-client
-version:        1.0.0
+version:        1.1.0
 synopsis:       Core library to communicate with Rollbar API.
 description:    Please see the README on GitHub at
                 <https://github.com/stackbuilders/rollbar-haskell/tree/master/rollbar-client>

--- a/rollbar-client/rollbar-client.cabal
+++ b/rollbar-client/rollbar-client.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 81d6afa5ec6b2f06fd39127d2ad1f8ad60dc296787ba7008b4850224495641fe
+-- hash: 372dae78f9159532940f589cb4a58365621fc289aae679dfac95e4b6ba477ed7
 
 name:           rollbar-client
 version:        1.1.0
@@ -24,7 +24,7 @@ tested-with:
 build-type:     Simple
 extra-source-files:
     README.md
-    CHANGELOG.md
+    ChangeLog.md
 
 source-repository head
   type: git

--- a/rollbar-client/rollbar-client.cabal
+++ b/rollbar-client/rollbar-client.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 00c54f5f1b124b9d08c5cbe143b9aef68916a289a7a63068ae10e692a1524f91
+-- hash: 1931cea8ad6754d11a0a9999cf3bd306f24d3b9b492d2bd442edbd99b1f1a78d
 
 name:           rollbar-client
 version:        1.0.0
@@ -24,7 +24,7 @@ tested-with:
 build-type:     Simple
 extra-source-files:
     README.md
-    ChangeLog.md
+    CHANGELOG.md
 
 source-repository head
   type: git

--- a/rollbar-wai/ChangeLog.md
+++ b/rollbar-wai/ChangeLog.md
@@ -1,3 +1,14 @@
 # Changelog for rollbar-wai
 
+All notable changes to this project will be documented in this file.
+
+## [1.1.0] - 2024-05-28
+
+### Changed
+- Added support for GHC 9.4.7
+- Changed `text` dependency upper bound: we now support `text-2.0.X.X`.
+
+### Removed
+- Support for GHC 8.10.2 (in favor of GHC 8.10.7)
+
 ## Unreleased changes

--- a/rollbar-wai/package.yaml
+++ b/rollbar-wai/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-wai
-version: 1.0.0
+version: 1.1.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-wai/package.yaml
+++ b/rollbar-wai/package.yaml
@@ -9,7 +9,7 @@ tested-with: GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 
 extra-source-files:
   - README.md
-  - ChangeLog.md
+  - CHANGELOG.md
 
 synopsis: >
   Provides error reporting capabilities to WAI based applications through

--- a/rollbar-wai/package.yaml
+++ b/rollbar-wai/package.yaml
@@ -9,7 +9,7 @@ tested-with: GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 
 extra-source-files:
   - README.md
-  - CHANGELOG.md
+  - ChangeLog.md
 
 synopsis: >
   Provides error reporting capabilities to WAI based applications through

--- a/rollbar-wai/rollbar-wai.cabal
+++ b/rollbar-wai/rollbar-wai.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 338501405a8e05e08c35891eef7199b4abdf405c3235c841d549307a0a9f3a44
+-- hash: 2ba224bc6db40a624010bece934990a32caa6f2f52115acb984f1c95461db94d
 
 name:           rollbar-wai
-version:        1.0.0
+version:        1.1.0
 synopsis:       Provides error reporting capabilities to WAI based applications through Rollbar API.
 
 description:    Please see the README on GitHub at

--- a/rollbar-wai/rollbar-wai.cabal
+++ b/rollbar-wai/rollbar-wai.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2ba224bc6db40a624010bece934990a32caa6f2f52115acb984f1c95461db94d
+-- hash: ec084557ab6ac4fa78cda03d7566582d95296b617cdf5f55ec5d6a8ab9bad8c8
 
 name:           rollbar-wai
 version:        1.1.0
@@ -25,7 +25,7 @@ tested-with:
 build-type:     Simple
 extra-source-files:
     README.md
-    CHANGELOG.md
+    ChangeLog.md
 
 source-repository head
   type: git

--- a/rollbar-wai/rollbar-wai.cabal
+++ b/rollbar-wai/rollbar-wai.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b1784f3e45d1f870ae1ea4567c427a2eb4605d9103bde27be65e2ab8698e74ba
+-- hash: 338501405a8e05e08c35891eef7199b4abdf405c3235c841d549307a0a9f3a44
 
 name:           rollbar-wai
 version:        1.0.0
@@ -25,7 +25,7 @@ tested-with:
 build-type:     Simple
 extra-source-files:
     README.md
-    ChangeLog.md
+    CHANGELOG.md
 
 source-repository head
   type: git

--- a/rollbar-yesod/ChangeLog.md
+++ b/rollbar-yesod/ChangeLog.md
@@ -1,3 +1,22 @@
 # Changelog for rollbar-yesod
 
-## Unreleased changes
+All notable changes to this project will be documented in this file.
+
+## [1.1.0] - 2024-05-28
+
+### Changed
+- Added support for GHC 9.4.7
+
+### Removed
+- Support for GHC 8.10.2 (in favor of GHC 8.10.7)
+
+## [1.0.0] - 2022-12-28
+
+### Changed
+
+- Updated dependency aeson version.
+- Updated base version
+
+### Removed
+
+- Support for GHC 8.6.1

--- a/rollbar-yesod/package.yaml
+++ b/rollbar-yesod/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-yesod
-version: 1.0.0
+version: 1.1.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-yesod/package.yaml
+++ b/rollbar-yesod/package.yaml
@@ -9,7 +9,7 @@ tested-with: GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 
 extra-source-files:
   - README.md
-  - ChangeLog.md
+  - CHANGELOG.md
 
 # Metadata used when publishing your package
 synopsis: >

--- a/rollbar-yesod/package.yaml
+++ b/rollbar-yesod/package.yaml
@@ -9,7 +9,7 @@ tested-with: GHC ==8.8.4, GHC ==8.10.7, GHC ==9.4.7
 
 extra-source-files:
   - README.md
-  - CHANGELOG.md
+  - ChangeLog.md
 
 # Metadata used when publishing your package
 synopsis: >

--- a/rollbar-yesod/rollbar-yesod.cabal
+++ b/rollbar-yesod/rollbar-yesod.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5125e85e486dd50a57b0879cae6ecfc7c5a756c587f33eef2d2c5d38a915969f
+-- hash: 453892067ab7e968d62c4251df2dc2782e6b5dac542a250a45004c2aa39ac506
 
 name:           rollbar-yesod
-version:        1.0.0
+version:        1.1.0
 synopsis:       Provides error reporting capabilities to Yesod applications through Rollbar API.
 
 description:    Please see the README on GitHub at

--- a/rollbar-yesod/rollbar-yesod.cabal
+++ b/rollbar-yesod/rollbar-yesod.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 453892067ab7e968d62c4251df2dc2782e6b5dac542a250a45004c2aa39ac506
+-- hash: 73910af7b84cf6d3325d9af612c5d29651317e6e29596c3660c64a32be67da87
 
 name:           rollbar-yesod
 version:        1.1.0
@@ -25,7 +25,7 @@ tested-with:
 build-type:     Simple
 extra-source-files:
     README.md
-    CHANGELOG.md
+    ChangeLog.md
 
 source-repository head
   type: git

--- a/rollbar-yesod/rollbar-yesod.cabal
+++ b/rollbar-yesod/rollbar-yesod.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 928697afe6fc01901eb1e55e4cf239102c43949165f2e912442b44fc521a3dfb
+-- hash: 5125e85e486dd50a57b0879cae6ecfc7c5a756c587f33eef2d2c5d38a915969f
 
 name:           rollbar-yesod
 version:        1.0.0
@@ -25,7 +25,7 @@ tested-with:
 build-type:     Simple
 extra-source-files:
     README.md
-    ChangeLog.md
+    CHANGELOG.md
 
 source-repository head
   type: git


### PR DESCRIPTION
This PR moves the version of the packages to 1.1.0, in preparation for distributing this new release. 