### PR TITLE
fix(client): use the exception type name as the Rollbar class

### DIFF
--- a/rollbar-cli/ChangeLog.md
+++ b/rollbar-cli/ChangeLog.md
@@ -6,9 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Version bump only, to stay in step with the other rollbar packages. The CLI
-  does not report exceptions, so it is unaffected by the `mkException` change in
-  rollbar-client 1.2.0.
+- Version bump only, keeping in step with the other rollbar packages; the CLI
+  does not report exceptions.
 
 ## [1.1.0] - 2024-05-28
 

--- a/rollbar-cli/ChangeLog.md
+++ b/rollbar-cli/ChangeLog.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2026-08-18
+
+### Changed
+
+- Version bump only, to stay in step with the other rollbar packages. The CLI
+  does not report exceptions, so it is unaffected by the `mkException` change in
+  rollbar-client 1.2.0.
+
 ## [1.1.0] - 2024-05-28
 
 ### Changed

--- a/rollbar-cli/package.yaml
+++ b/rollbar-cli/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-cli
-version: 1.1.1
+version: 1.2.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-cli/rollbar-cli.cabal
+++ b/rollbar-cli/rollbar-cli.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           rollbar-cli
-version:        1.1.1
+version:        1.2.0
 synopsis:       Simple CLI tool to perform commons tasks such as tracking deploys.
 description:    Please see the README on GitHub at
                 <https://github.com/stackbuilders/rollbar-haskell/tree/master/rollbar-cli>

--- a/rollbar-client/ChangeLog.md
+++ b/rollbar-client/ChangeLog.md
@@ -6,27 +6,18 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- **Breaking:** `mkException` now sets the exception class to the name of the
-  exception type, unwrapping the `SomeException` and `SomeAsyncException`
-  wrappers first, instead of the rendered exception text. The rendered text is
-  kept as the message (its first line, when non-blank) and as the description
-  (in full), so no information is lost. Rollbar groups trace
-  payloads by class, and rendered exceptions routinely embed per-occurrence data
-  such as urls, ids and call stacks, so the previous behaviour created a new
-  item for nearly every occurrence instead of one per failure cause.
+- **Breaking:** `mkException` now sets the exception class to the exception
+  type name (unwrapping `SomeException` and `SomeAsyncException`) instead of
+  the rendered exception text, which embeds per-occurrence data and created a
+  new Rollbar item for nearly every occurrence. The rendered text is kept as
+  the message (first line) and the description (in full).
 
   Upgrading re-groups existing items once: occurrences reported after the
-  upgrade carry new class values, so Rollbar files them as new items rather than
-  adding to the ones already open.
+  upgrade carry new class values, so Rollbar files them under new items.
 
-  Known limitation: this library does not populate stack frames yet, so
-  Rollbar's default fingerprint (frame filenames and methods plus the exception
-  class) reduces to the class alone and all occurrences of one exception type
-  are grouped into a single item. Applications that need finer-grained grouping
-  can set the `fingerprint` field on the `Item` before sending it, for example
-  through `rollbarOnExceptionWith`. The exception message is not part of
-  Rollbar's default fingerprint, but projects that enabled Rollbar's "include
-  message in fingerprint" setting will see items split per distinct message.
+  Traces still carry no stack frames, so all occurrences of one exception type
+  group into a single item; set `fingerprint` on the `Item` for finer-grained
+  grouping.
 
 ## [1.1.0] - 2024-05-28
 

--- a/rollbar-client/ChangeLog.md
+++ b/rollbar-client/ChangeLog.md
@@ -19,6 +19,15 @@ All notable changes to this project will be documented in this file.
   upgrade carry new class values, so Rollbar files them as new items rather than
   adding to the ones already open.
 
+  Known limitation: this library does not populate stack frames yet, so
+  Rollbar's default fingerprint (frame filenames and methods plus the exception
+  class) reduces to the class alone and all occurrences of one exception type
+  are grouped into a single item. Applications that need finer-grained grouping
+  can set the `fingerprint` field on the `Item` before sending it, for example
+  through `rollbarOnExceptionWith`. The exception message is not part of
+  Rollbar's default fingerprint, but projects that enabled Rollbar's "include
+  message in fingerprint" setting will see items split per distinct message.
+
 ## [1.1.0] - 2024-05-28
 
 ### Changed

--- a/rollbar-client/ChangeLog.md
+++ b/rollbar-client/ChangeLog.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2026-08-18
+
+### Changed
+
+- **Breaking:** `mkException` now sets the exception class to the name of the
+  exception type, unwrapping `SomeException` first, instead of the rendered
+  exception text. The rendered text is kept as the message (its first line) and
+  as the description (in full), so no information is lost. Rollbar groups trace
+  payloads by class, and rendered exceptions routinely embed per-occurrence data
+  such as urls, ids and call stacks, so the previous behaviour created a new
+  item for nearly every occurrence instead of one per failure cause.
+
+  Upgrading re-groups existing items once: occurrences reported after the
+  upgrade carry new class values, so Rollbar files them as new items rather than
+  adding to the ones already open.
+
 ## [1.1.0] - 2024-05-28
 
 ### Changed

--- a/rollbar-client/ChangeLog.md
+++ b/rollbar-client/ChangeLog.md
@@ -7,9 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - **Breaking:** `mkException` now sets the exception class to the name of the
-  exception type, unwrapping `SomeException` first, instead of the rendered
-  exception text. The rendered text is kept as the message (its first line) and
-  as the description (in full), so no information is lost. Rollbar groups trace
+  exception type, unwrapping the `SomeException` and `SomeAsyncException`
+  wrappers first, instead of the rendered exception text. The rendered text is
+  kept as the message (its first line, when non-blank) and as the description
+  (in full), so no information is lost. Rollbar groups trace
   payloads by class, and rendered exceptions routinely embed per-occurrence data
   such as urls, ids and call stacks, so the previous behaviour created a new
   item for nearly every occurrence instead of one per failure cause.

--- a/rollbar-client/package.yaml
+++ b/rollbar-client/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-client
-version: 1.1.1
+version: 1.2.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."

--- a/rollbar-client/rollbar-client.cabal
+++ b/rollbar-client/rollbar-client.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           rollbar-client
-version:        1.1.1
+version:        1.2.0
 synopsis:       Core library to communicate with Rollbar API.
 description:    Please see the README on GitHub at
                 <https://github.com/stackbuilders/rollbar-haskell/tree/master/rollbar-client>

--- a/rollbar-client/src/Rollbar/Client/Item.hs
+++ b/rollbar-client/src/Rollbar/Client/Item.hs
@@ -250,7 +250,10 @@ instance ToJSON Exception where
 -- message up to its first newline, when non-blank.
 --
 -- Traces carry no stack frames yet, so all occurrences of one exception type
--- group into a single item; set 'fingerprint' on the 'Item' to refine that.
+-- group into a single item. The type name is also unqualified, so two
+-- exception types sharing a name (say, req's and http-client's
+-- @HttpException@) share a class. Set 'fingerprint' on the 'Item' to refine
+-- the grouping in either case.
 mkException :: E.Exception e => e -> Exception
 mkException e = Exception
   { exceptionClass = T.pack $ exceptionTypeName $ E.toException e

--- a/rollbar-client/src/Rollbar/Client/Item.hs
+++ b/rollbar-client/src/Rollbar/Client/Item.hs
@@ -244,21 +244,32 @@ instance ToJSON Exception where
 
 -- | Builds a 'Exception' based on 'E.SomeException'.
 --
--- The class is the name of the concrete exception type, unwrapping
--- 'E.SomeException' first, since Rollbar groups trace payloads by class and
--- rendered exceptions usually embed per-occurrence data such as urls, ids and
--- call stacks, which would mint a new item on every occurrence. The rendered
--- text is kept in full as the description, and its first line as the message.
+-- The class is the name of the concrete exception type, unwrapping the
+-- 'E.SomeException' and 'E.SomeAsyncException' wrappers first, since Rollbar
+-- groups trace payloads by class and rendered exceptions usually embed
+-- per-occurrence data such as urls, ids and call stacks, which would mint a
+-- new item on every occurrence. The rendered text is kept in full as the
+-- description, and its first line as the message, unless that line is blank.
 mkException :: E.Exception e => e -> Exception
-mkException e =
-  case E.toException e of
-    E.SomeException inner -> Exception
-      { exceptionClass = T.pack $ show $ typeOf inner
-      , exceptionMessage = Just $ T.takeWhile (/= '\n') rendered
-      , exceptionDescription = Just rendered
-      }
+mkException e = Exception
+  { exceptionClass = T.pack $ exceptionTypeName $ E.toException e
+  , exceptionMessage = if T.null firstLine then Nothing else Just firstLine
+  , exceptionDescription = Just rendered
+  }
   where
     rendered = T.pack $ E.displayException e
+    firstLine = T.dropWhileEnd (== '\r') $ T.takeWhile (/= '\n') rendered
+
+-- | Returns the name of the innermost exception type, peeling off the
+-- 'E.SomeAsyncException' wrapper used by async exception hierarchies.
+exceptionTypeName :: E.SomeException -> String
+exceptionTypeName se =
+  case E.fromException se of
+    Just (E.SomeAsyncException inner) ->
+      exceptionTypeName $ E.SomeException inner
+    Nothing ->
+      case se of
+        E.SomeException inner -> show $ typeOf inner
 
 data Message = Message
   { messageBody :: Text

--- a/rollbar-client/src/Rollbar/Client/Item.hs
+++ b/rollbar-client/src/Rollbar/Client/Item.hs
@@ -250,6 +250,11 @@ instance ToJSON Exception where
 -- per-occurrence data such as urls, ids and call stacks, which would mint a
 -- new item on every occurrence. The rendered text is kept in full as the
 -- description, and its first line as the message, unless that line is blank.
+--
+-- Since the traces built by this library carry no stack frames yet, Rollbar's
+-- default fingerprint reduces to the class alone, grouping all occurrences of
+-- one exception type into a single item. Set 'fingerprint' on the 'Item' to
+-- control grouping at a finer grain.
 mkException :: E.Exception e => e -> Exception
 mkException e = Exception
   { exceptionClass = T.pack $ exceptionTypeName $ E.toException e

--- a/rollbar-client/src/Rollbar/Client/Item.hs
+++ b/rollbar-client/src/Rollbar/Client/Item.hs
@@ -38,6 +38,7 @@ import Data.Aeson
 import Data.Maybe (catMaybes)
 import Data.Monoid (Endo(..))
 import Data.Text (Text)
+import Data.Typeable (typeOf)
 import Data.Version (showVersion)
 import Network.HTTP.Req
 import Rollbar.Client.Internal
@@ -242,12 +243,22 @@ instance ToJSON Exception where
     ]
 
 -- | Builds a 'Exception' based on 'E.SomeException'.
+--
+-- The class is the name of the concrete exception type, unwrapping
+-- 'E.SomeException' first, since Rollbar groups trace payloads by class and
+-- rendered exceptions usually embed per-occurrence data such as urls, ids and
+-- call stacks, which would mint a new item on every occurrence. The rendered
+-- text is kept in full as the description, and its first line as the message.
 mkException :: E.Exception e => e -> Exception
-mkException e = Exception
-  { exceptionClass = T.pack $ E.displayException e
-  , exceptionMessage = Nothing
-  , exceptionDescription = Nothing
-  }
+mkException e =
+  case E.toException e of
+    E.SomeException inner -> Exception
+      { exceptionClass = T.pack $ show $ typeOf inner
+      , exceptionMessage = Just $ T.takeWhile (/= '\n') rendered
+      , exceptionDescription = Just rendered
+      }
+  where
+    rendered = T.pack $ E.displayException e
 
 data Message = Message
   { messageBody :: Text

--- a/rollbar-client/src/Rollbar/Client/Item.hs
+++ b/rollbar-client/src/Rollbar/Client/Item.hs
@@ -244,17 +244,13 @@ instance ToJSON Exception where
 
 -- | Builds a 'Exception' based on 'E.SomeException'.
 --
--- The class is the name of the concrete exception type, unwrapping the
--- 'E.SomeException' and 'E.SomeAsyncException' wrappers first, since Rollbar
--- groups trace payloads by class and rendered exceptions usually embed
--- per-occurrence data such as urls, ids and call stacks, which would mint a
--- new item on every occurrence. The rendered text is kept in full as the
--- description, and its first line as the message, unless that line is blank.
+-- The class is the concrete exception type name, unwrapping 'E.SomeException'
+-- and 'E.SomeAsyncException' first, since Rollbar groups trace payloads by
+-- class. The rendered text is kept as the description in full and as the
+-- message up to its first newline, when non-blank.
 --
--- Since the traces built by this library carry no stack frames yet, Rollbar's
--- default fingerprint reduces to the class alone, grouping all occurrences of
--- one exception type into a single item. Set 'fingerprint' on the 'Item' to
--- control grouping at a finer grain.
+-- Traces carry no stack frames yet, so all occurrences of one exception type
+-- group into a single item; set 'fingerprint' on the 'Item' to refine that.
 mkException :: E.Exception e => e -> Exception
 mkException e = Exception
   { exceptionClass = T.pack $ exceptionTypeName $ E.toException e
@@ -265,8 +261,7 @@ mkException e = Exception
     rendered = T.pack $ E.displayException e
     firstLine = T.dropWhileEnd (== '\r') $ T.takeWhile (/= '\n') rendered
 
--- | Returns the name of the innermost exception type, peeling off the
--- 'E.SomeAsyncException' wrapper used by async exception hierarchies.
+-- | Name of the innermost exception type, unwrapping 'E.SomeAsyncException'.
 exceptionTypeName :: E.SomeException -> String
 exceptionTypeName se =
   case E.fromException se of

--- a/rollbar-client/test/Rollbar/ClientSpec.hs
+++ b/rollbar-client/test/Rollbar/ClientSpec.hs
@@ -198,7 +198,7 @@ spec = do
             , title = Nothing
             , uuid = Just "12345"
             , fingerprint = Nothing
-            , itemNotifier = Notifier "rollbar-client" "1.1.1"
+            , itemNotifier = Notifier "rollbar-client" "1.2.0"
             }
           jsonItem = decodeUtf8 $ DBL.toStrict $ encode item
 

--- a/rollbar-client/test/Rollbar/ClientSpec.hs
+++ b/rollbar-client/test/Rollbar/ClientSpec.hs
@@ -7,6 +7,7 @@ module Rollbar.ClientSpec
   ( spec
   ) where
 
+import qualified Control.Exception as E
 import qualified Data.Aeson.KeyMap as KM
 
 import Control.Monad.Reader
@@ -30,6 +31,17 @@ instance FromJSON Package where
 
 instance HasSettings (Reader Settings) where
   getSettings = ask
+
+-- | An exception whose rendered form spans several lines and carries
+-- per-occurrence data, the way real exceptions usually do.
+newtype TestException = TestException String
+  deriving (Eq, Show)
+
+instance E.Exception TestException where
+  displayException (TestException detail) =
+    "Something went wrong: " <> detail <> "\n" <>
+    "CallStack (from HasCallStack):\n" <>
+    "  error, called at src/Main.hs:42:9 in main:Main"
 
 spec :: Spec
 spec = do
@@ -93,6 +105,31 @@ spec = do
         { notifierName = packageName
         , notifierVersion = packageVersion
         }
+
+  describe "mkException" $ do
+    let rendered =
+          "Something went wrong: 42\n\
+          \CallStack (from HasCallStack):\n\
+          \  error, called at src/Main.hs:42:9 in main:Main"
+
+    it "uses the exception type name as the class" $
+      exceptionClass (mkException $ TestException "42") `shouldBe` "TestException"
+
+    it "unwraps SomeException to reach the concrete exception type" $
+      exceptionClass (mkException $ E.toException $ TestException "42")
+        `shouldBe` "TestException"
+
+    it "gives occurrences of the same type the same class" $
+      exceptionClass (mkException $ TestException "42")
+        `shouldBe` exceptionClass (mkException $ TestException "1337")
+
+    it "puts the first line of the rendered exception in the message" $
+      exceptionMessage (mkException $ TestException "42")
+        `shouldBe` Just "Something went wrong: 42"
+
+    it "keeps the whole rendered exception in the description" $
+      exceptionDescription (mkException $ TestException "42")
+        `shouldBe` Just rendered
 
   before (readSettings "rollbar.yaml") $ do
     describe "ping" $

--- a/rollbar-client/test/Rollbar/ClientSpec.hs
+++ b/rollbar-client/test/Rollbar/ClientSpec.hs
@@ -32,8 +32,7 @@ instance FromJSON Package where
 instance HasSettings (Reader Settings) where
   getSettings = ask
 
--- | An exception whose rendered form spans several lines and carries
--- per-occurrence data, the way real exceptions usually do.
+-- | An exception rendered across several lines, the way real ones are.
 newtype TestException = TestException String
   deriving (Eq, Show)
 
@@ -43,8 +42,7 @@ instance E.Exception TestException where
     "CallStack (from HasCallStack):\n" <>
     "  error, called at src/Main.hs:42:9 in main:Main"
 
--- | An exception thrown through the async exception hierarchy, the way
--- timeouts and thread kills are.
+-- | An exception reported through the async exception hierarchy.
 data AsyncTestException = AsyncTestException
   deriving Show
 

--- a/rollbar-client/test/Rollbar/ClientSpec.hs
+++ b/rollbar-client/test/Rollbar/ClientSpec.hs
@@ -43,6 +43,22 @@ instance E.Exception TestException where
     "CallStack (from HasCallStack):\n" <>
     "  error, called at src/Main.hs:42:9 in main:Main"
 
+-- | An exception thrown through the async exception hierarchy, the way
+-- timeouts and thread kills are.
+data AsyncTestException = AsyncTestException
+  deriving Show
+
+instance E.Exception AsyncTestException where
+  toException = E.asyncExceptionToException
+  fromException = E.asyncExceptionFromException
+
+-- | An exception rendered verbatim, to exercise first-line edge cases.
+newtype RawException = RawException String
+  deriving Show
+
+instance E.Exception RawException where
+  displayException (RawException s) = s
+
 spec :: Spec
 spec = do
   describe "getRequestModifier" $ do
@@ -107,10 +123,7 @@ spec = do
         }
 
   describe "mkException" $ do
-    let rendered =
-          "Something went wrong: 42\n\
-          \CallStack (from HasCallStack):\n\
-          \  error, called at src/Main.hs:42:9 in main:Main"
+    let rendered = T.pack $ E.displayException $ TestException "42"
 
     it "uses the exception type name as the class" $
       exceptionClass (mkException $ TestException "42") `shouldBe` "TestException"
@@ -118,6 +131,10 @@ spec = do
     it "unwraps SomeException to reach the concrete exception type" $
       exceptionClass (mkException $ E.toException $ TestException "42")
         `shouldBe` "TestException"
+
+    it "unwraps SomeAsyncException to reach the concrete exception type" $
+      exceptionClass (mkException AsyncTestException)
+        `shouldBe` "AsyncTestException"
 
     it "gives occurrences of the same type the same class" $
       exceptionClass (mkException $ TestException "42")
@@ -130,6 +147,14 @@ spec = do
     it "keeps the whole rendered exception in the description" $
       exceptionDescription (mkException $ TestException "42")
         `shouldBe` Just rendered
+
+    it "drops a trailing carriage return from the message" $
+      exceptionMessage (mkException $ RawException "Boom\r\nDetails")
+        `shouldBe` Just "Boom"
+
+    it "omits the message when the first rendered line is blank" $
+      exceptionMessage (mkException $ RawException "\nDetails")
+        `shouldBe` Nothing
 
   before (readSettings "rollbar.yaml") $ do
     describe "ping" $

--- a/rollbar-wai/ChangeLog.md
+++ b/rollbar-wai/ChangeLog.md
@@ -6,11 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- **Breaking:** exceptions captured by `rollbarOnException` and
-  `rollbarOnExceptionWith` are now reported with the exception type name as the
-  Rollbar class, and the rendered exception text as the message and description.
-  Upgrading re-groups existing items once; see the rollbar-client 1.2.0 entry
-  for the details. This requires rollbar-client >= 1.2.
+- **Breaking:** captured exceptions are now reported with the exception type
+  name as the Rollbar class and the rendered text as message and description.
+  Upgrading re-groups existing items once; see the rollbar-client 1.2.0 entry.
+  Requires rollbar-client >= 1.2.
 
 ## [1.1.0] - 2024-05-28
 

--- a/rollbar-wai/ChangeLog.md
+++ b/rollbar-wai/ChangeLog.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2026-08-18
+
+### Changed
+
+- **Breaking:** exceptions captured by `rollbarOnException` and
+  `rollbarOnExceptionWith` are now reported with the exception type name as the
+  Rollbar class, and the rendered exception text as the message and description.
+  Upgrading re-groups existing items once; see the rollbar-client 1.2.0 entry
+  for the details. This requires rollbar-client >= 1.2.
+
 ## [1.1.0] - 2024-05-28
 
 ### Changed

--- a/rollbar-wai/package.yaml
+++ b/rollbar-wai/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-wai
-version: 1.1.1
+version: 1.2.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."
@@ -43,7 +43,7 @@ library:
     - bytestring >= 0.10 && < 1
     - case-insensitive >= 1.2 && < 2
     - http-types >= 0.12 && < 1
-    - rollbar-client >= 1.0 && < 2
+    - rollbar-client >= 1.2 && < 2
     - text >= 1.2 && < 2.2
     - unordered-containers >= 0.2 && < 1
     - wai >= 3.2 && < 4

--- a/rollbar-wai/rollbar-wai.cabal
+++ b/rollbar-wai/rollbar-wai.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           rollbar-wai
-version:        1.1.1
+version:        1.2.0
 synopsis:       Provides error reporting capabilities to WAI based applications through Rollbar API.
 
 description:    Please see the README on GitHub at
@@ -48,7 +48,7 @@ library
     , bytestring >=0.10 && <1
     , case-insensitive >=1.2 && <2
     , http-types >=0.12 && <1
-    , rollbar-client >=1.0 && <2
+    , rollbar-client >=1.2 && <2
     , text >=1.2 && <2.2
     , unordered-containers >=0.2 && <1
     , wai >=3.2 && <4

--- a/rollbar-wai/test/Rollbar/WaiSpec.hs
+++ b/rollbar-wai/test/Rollbar/WaiSpec.hs
@@ -11,7 +11,7 @@ import qualified Network.Wai as W
 import qualified Network.Wai.Handler.Warp as W
 
 import Control.Concurrent (threadDelay)
-import Control.Monad (join, void)
+import Control.Monad (join)
 import Control.Monad.IO.Class
 import Data.Aeson
 import Data.IORef
@@ -62,15 +62,6 @@ spec = before getSettingsAndItemRef $
                 , requestUserIp = ""
                 }
             )
-
-    context "when the request handler throws" $
-      it "reports the exception type as the class" $
-        withApp $ \itemRef warpPort -> do
-          let url = http "localhost" /: "error"
-          void $ runReq
-            (defaultHttpConfig { httpConfigCheckResponse = \_ _ _ -> Nothing })
-            (req GET url NoReqBody bsResponse $ port warpPort)
-          threadDelay 500
           exception <- fmap (>>= itemException) $ readIORef itemRef
           fmap exceptionClass exception `shouldBe` Just "ErrorCall"
           fmap exceptionMessage exception `shouldBe` Just (Just "Boom")

--- a/rollbar-wai/test/Rollbar/WaiSpec.hs
+++ b/rollbar-wai/test/Rollbar/WaiSpec.hs
@@ -11,7 +11,7 @@ import qualified Network.Wai as W
 import qualified Network.Wai.Handler.Warp as W
 
 import Control.Concurrent (threadDelay)
-import Control.Monad (join)
+import Control.Monad (join, void)
 import Control.Monad.IO.Class
 import Data.Aeson
 import Data.IORef
@@ -63,6 +63,18 @@ spec = before getSettingsAndItemRef $
                 }
             )
 
+    context "when the request handler throws" $
+      it "reports the exception type as the class" $
+        withApp $ \itemRef warpPort -> do
+          let url = http "localhost" /: "error"
+          void $ runReq
+            (defaultHttpConfig { httpConfigCheckResponse = \_ _ _ -> Nothing })
+            (req GET url NoReqBody bsResponse $ port warpPort)
+          threadDelay 500
+          exception <- fmap (>>= itemException) $ readIORef itemRef
+          fmap exceptionClass exception `shouldBe` Just "ErrorCall"
+          fmap exceptionMessage exception `shouldBe` Just (Just "Boom")
+
 
 getSettingsAndItemRef :: IO (Settings, IORef (Maybe Item))
 getSettingsAndItemRef =
@@ -91,3 +103,9 @@ createItemFake itemRef item = do
   requestModifier <- getRequestModifier
   liftIO $ writeIORef itemRef $ Just $
     item { itemRequest = requestModifier <$> itemRequest item }
+
+itemException :: Item -> Maybe Exception
+itemException item =
+  case bodyPayload $ itemBody item of
+    PayloadTrace trace -> Just $ traceException trace
+    _ -> Nothing

--- a/rollbar-yesod/ChangeLog.md
+++ b/rollbar-yesod/ChangeLog.md
@@ -6,12 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- **Breaking:** exceptions captured by `rollbarYesodMiddleware` and
-  `rollbarYesodMiddlewareWith` are now reported with the exception type name as
-  the Rollbar class, and the rendered exception text as the message and
-  description. Upgrading re-groups existing items once; see the rollbar-client
-  1.2.0 entry for the details. This requires rollbar-client >= 1.2 and
-  rollbar-wai >= 1.2.
+- **Breaking:** captured exceptions are now reported with the exception type
+  name as the Rollbar class and the rendered text as message and description.
+  Upgrading re-groups existing items once; see the rollbar-client 1.2.0 entry.
+  Requires rollbar-client >= 1.2 and rollbar-wai >= 1.2.
 
 ## [1.1.0] - 2024-05-28
 

--- a/rollbar-yesod/ChangeLog.md
+++ b/rollbar-yesod/ChangeLog.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2026-08-18
+
+### Changed
+
+- **Breaking:** exceptions captured by `rollbarYesodMiddleware` and
+  `rollbarYesodMiddlewareWith` are now reported with the exception type name as
+  the Rollbar class, and the rendered exception text as the message and
+  description. Upgrading re-groups existing items once; see the rollbar-client
+  1.2.0 entry for the details. This requires rollbar-client >= 1.2 and
+  rollbar-wai >= 1.2.
+
 ## [1.1.0] - 2024-05-28
 
 ### Changed

--- a/rollbar-yesod/package.yaml
+++ b/rollbar-yesod/package.yaml
@@ -1,5 +1,5 @@
 name: rollbar-yesod
-version: 1.1.1
+version: 1.2.0
 github: "stackbuilders/rollbar-haskell"
 license: MIT
 author: "Stack Builders Inc."
@@ -40,8 +40,8 @@ _exe-ghc-options: &exe-ghc-options
 library:
   source-dirs: src
   dependencies:
-    - rollbar-client >= 1.0 && < 2
-    - rollbar-wai >= 1.0 && < 2
+    - rollbar-client >= 1.2 && < 2
+    - rollbar-wai >= 1.2 && < 2
     - unliftio >= 0.2 && < 1
     - wai >= 3.2 && < 4
     - yesod-core >= 1.6 && < 2

--- a/rollbar-yesod/rollbar-yesod.cabal
+++ b/rollbar-yesod/rollbar-yesod.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           rollbar-yesod
-version:        1.1.1
+version:        1.2.0
 synopsis:       Provides error reporting capabilities to Yesod applications through Rollbar API.
 
 description:    Please see the README on GitHub at
@@ -44,8 +44,8 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.18 && <5
-    , rollbar-client >=1.0 && <2
-    , rollbar-wai >=1.0 && <2
+    , rollbar-client >=1.2 && <2
+    , rollbar-wai >=1.2 && <2
     , unliftio >=0.2 && <1
     , wai >=3.2 && <4
     , yesod-core >=1.6 && <2


### PR DESCRIPTION
## Summary

`mkException` filled the `class` field with the full rendered exception text. Rollbar groups trace payloads by class (plus stack frames), and rendered exceptions routinely embed per-occurrence data — urls, ids, call stacks — so nearly every occurrence minted its own Rollbar item instead of grouping by failure cause.

- `class` is now the concrete exception type name, unwrapping the `SomeException` and `SomeAsyncException` wrappers (the latter so timeouts and other async-hierarchy exceptions report their real type rather than `SomeAsyncException`)
- `message` is the first line of `displayException` (trailing `\r` dropped, omitted when blank)
- `description` keeps the full rendered text, so no information is lost

Both call sites benefit: `withRollbar` (rollbar-client) and the wai/yesod middleware.

Refs #98 — the *empty frames* section of the issue is deliberately **not** addressed here; it's an API design question (caller-supplied frames vs `HasCallStack` vs GHC 9.10+ backtraces) whose resolution will change grouping again. The changelog documents the interim: with no frames, occurrences of one exception type share a single item, and `fingerprint` on `Item` is the escape hatch.

## Breaking change

Upgrading re-groups existing Rollbar items once: occurrences reported after the upgrade carry new class values, so Rollbar files them under new items. All four packages bump to **1.2.0** in lockstep (matching previous releases); rollbar-wai and rollbar-yesod now require `rollbar-client >= 1.2` so their changelog claims hold for any build plan.

## Tests

- `ClientSpec`: 8 new pure examples for `mkException` — type-name class, `SomeException`/`SomeAsyncException` unwrapping, stable class across occurrences, first-line message, CR and blank-line edges, full description
- `WaiSpec`: the existing non-200 example now also asserts the reported exception's class and message end-to-end through `rollbarOnExceptionWith` (covers the yesod path, which routes through the same function)

Verified locally on GHC 9.8.4: all four packages build warning-free under `-Wall`; client 15/15, wai 2/2, yesod 2/2 specs pass (live-API specs excluded — they need a real `ROLLBAR_TOKEN`). Class/first-line behavior additionally probed on GHC 9.12.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)