### PR TITLE
test: make the live Rollbar API specs conditional on ROLLBAR_TOKEN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,10 +75,9 @@ jobs:
       - name: Build
         run: cabal build all
       - name: Run tests
-        # The specs that talk to the real Rollbar API run only when
-        # ROLLBAR_TOKEN is set. Restore the env below once there is an
-        # active Rollbar account behind the secret:
-        #
-        #   env:
-        #     ROLLBAR_TOKEN: ${{ secrets.ROLLBAR_TOKEN }}
         run: cabal test all
+        env:
+          # When this secret is missing or empty, the specs that talk to the
+          # real Rollbar API are skipped; setting a valid token re-enables
+          # them without any workflow changes.
+          ROLLBAR_TOKEN: ${{ secrets.ROLLBAR_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           cabal-file: rollbar-client/rollbar-client.cabal
           ubuntu-version: latest
-          macos-version: 13
+          macos-version: latest
           version: 0.1.7.0
   build:
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,10 @@ jobs:
       - name: Build
         run: cabal build all
       - name: Run tests
+        # The specs that talk to the real Rollbar API run only when
+        # ROLLBAR_TOKEN is set. Restore the env below once there is an
+        # active Rollbar account behind the secret:
+        #
+        #   env:
+        #     ROLLBAR_TOKEN: ${{ secrets.ROLLBAR_TOKEN }}
         run: cabal test all
-        env:
-          ROLLBAR_TOKEN: ${{ secrets.ROLLBAR_TOKEN }}

--- a/rollbar-client/test/Rollbar/ClientSpec.hs
+++ b/rollbar-client/test/Rollbar/ClientSpec.hs
@@ -96,7 +96,7 @@ spec = do
         }
 
   mtoken <- runIO $ lookupEnv "ROLLBAR_TOKEN"
-  if maybe True (== "") mtoken
+  if mtoken == Nothing || mtoken == Just ""
     then describe "live API specs" $
       it "run only when ROLLBAR_TOKEN is set" $
         pendingWith "ROLLBAR_TOKEN is not set"

--- a/rollbar-client/test/Rollbar/ClientSpec.hs
+++ b/rollbar-client/test/Rollbar/ClientSpec.hs
@@ -16,6 +16,7 @@ import Data.Text.Encoding
 import Data.Text as T
 import Data.Yaml.Config
 import Rollbar.Client
+import System.Environment (lookupEnv)
 import Test.Hspec
 
 data Package = Package
@@ -94,57 +95,12 @@ spec = do
         , notifierVersion = packageVersion
         }
 
-  before (readSettings "rollbar.yaml") $ do
-    describe "ping" $
-      it "returns Pong" $ \settings ->
-        runRollbar settings ping `shouldReturn` Pong
-
-    describe "createItem" $ do
-      context "PayloadTrace" $
-        it "returns ItemId" $ \settings -> do
-          itemId <- runRollbar settings $ do
-            item <- mkItem $ PayloadTrace $ Trace [] $ Exception
-              { exceptionClass = "NameError"
-              , exceptionMessage = Just "global name 'foo' is not defined"
-              , exceptionDescription = Just "Something went wrong while trying to save the user object"
-              }
-            createItem item
-
-          itemId `shouldSatisfy` const True
-
-      context "PayloadTraceChain" $
-        it "returns ItemId" $ \settings -> do
-          itemId <- runRollbar settings $ do
-            item <- mkItem $ PayloadTraceChain $ pure $ Trace [] $ Exception
-              { exceptionClass = "NameError"
-              , exceptionMessage = Just "global name 'foo' is not defined"
-              , exceptionDescription = Just "Something went wrong while trying to save the user object"
-              }
-            createItem item
-
-          itemId `shouldSatisfy` const True
-
-      context "PayloadMessage" $
-        it "returns ItemId" $ \settings -> do
-          itemId <- runRollbar settings $ do
-            item <- mkItem $ PayloadMessage $ Message
-              { messageBody = "Request over threshold of 10 seconds"
-              , messageMetadata = KM.fromList
-                  [ ("route", "home#index")
-                  , ("time_elapsed", Number 15.23)
-                  ]
-              }
-            createItem item
-
-          itemId `shouldSatisfy` const True
-
-    describe "reportDeploy" $
-      it "returns DeployId" $ \settings -> do
-        deployId <- runRollbar settings $ do
-          deploy <- getRevision >>= mkDeploy
-          reportDeploy deploy
-
-        deployId `shouldSatisfy` (> 0)
+  mtoken <- runIO $ lookupEnv "ROLLBAR_TOKEN"
+  if maybe True (== "") mtoken
+    then describe "live API specs" $
+      it "run only when ROLLBAR_TOKEN is set" $
+        pendingWith "ROLLBAR_TOKEN is not set"
+    else liveApiSpecs
 
   describe "ToJSON Item" $ do
     context "when serializing to JSON" $ do
@@ -170,3 +126,58 @@ spec = do
 
       it "includes fields if they are Just values" $
         T.unpack jsonItem `shouldContain` "\"platform\":\"haskell\""
+
+-- | Specs that talk to the real Rollbar API; they run only when
+-- ROLLBAR_TOKEN is set.
+liveApiSpecs :: Spec
+liveApiSpecs = before (readSettings "rollbar.yaml") $ do
+  describe "ping" $
+    it "returns Pong" $ \settings ->
+      runRollbar settings ping `shouldReturn` Pong
+
+  describe "createItem" $ do
+    context "PayloadTrace" $
+      it "returns ItemId" $ \settings -> do
+        itemId <- runRollbar settings $ do
+          item <- mkItem $ PayloadTrace $ Trace [] $ Exception
+            { exceptionClass = "NameError"
+            , exceptionMessage = Just "global name 'foo' is not defined"
+            , exceptionDescription = Just "Something went wrong while trying to save the user object"
+            }
+          createItem item
+
+        itemId `shouldSatisfy` const True
+
+    context "PayloadTraceChain" $
+      it "returns ItemId" $ \settings -> do
+        itemId <- runRollbar settings $ do
+          item <- mkItem $ PayloadTraceChain $ pure $ Trace [] $ Exception
+            { exceptionClass = "NameError"
+            , exceptionMessage = Just "global name 'foo' is not defined"
+            , exceptionDescription = Just "Something went wrong while trying to save the user object"
+            }
+          createItem item
+
+        itemId `shouldSatisfy` const True
+
+    context "PayloadMessage" $
+      it "returns ItemId" $ \settings -> do
+        itemId <- runRollbar settings $ do
+          item <- mkItem $ PayloadMessage $ Message
+            { messageBody = "Request over threshold of 10 seconds"
+            , messageMetadata = KM.fromList
+                [ ("route", "home#index")
+                , ("time_elapsed", Number 15.23)
+                ]
+            }
+          createItem item
+
+        itemId `shouldSatisfy` const True
+
+  describe "reportDeploy" $
+    it "returns DeployId" $ \settings -> do
+      deployId <- runRollbar settings $ do
+        deploy <- getRevision >>= mkDeploy
+        reportDeploy deploy
+
+      deployId `shouldSatisfy` (> 0)

--- a/rollbar-wai/test/Rollbar/WaiSpec.hs
+++ b/rollbar-wai/test/Rollbar/WaiSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Rollbar.WaiSpec
@@ -34,7 +35,7 @@ spec = before getSettingsAndItemVar $
             (req GET url NoReqBody bsResponse $ port warpPort)
           responseStatusCode response `shouldBe` 200
           responseBody response `shouldBe` "OK"
-          threadDelay 100000
+          threadDelay 100_000
           tryReadMVar itemVar `shouldReturn` Nothing
 
     context "when the response status code is not 200" $
@@ -45,7 +46,7 @@ spec = before getSettingsAndItemVar $
             (defaultHttpConfig { httpConfigCheckResponse = \_ _ _ -> Nothing })
             (req GET url NoReqBody bsResponse $ port warpPort)
           response `shouldBe` "Something went wrong"
-          item <- timeout 5000000 $ readMVar itemVar
+          item <- timeout 5_000_000 $ readMVar itemVar
           let portAsText = T.pack $ show warpPort
           (item >>= itemRequest) `shouldBe` Just
             ( Request

--- a/rollbar-wai/test/Rollbar/WaiSpec.hs
+++ b/rollbar-wai/test/Rollbar/WaiSpec.hs
@@ -66,8 +66,17 @@ spec = before getSettingsAndItemRef $
 
 getSettingsAndItemRef :: IO (Settings, IORef (Maybe Item))
 getSettingsAndItemRef =
-  (,) <$> readSettings "rollbar.yaml"
+  (,) <$> pure testSettings
       <*> newIORef Nothing
+
+-- | These specs never call the Rollbar API, so any token works.
+testSettings :: Settings
+testSettings = Settings
+  { settingsToken = Token "invalid-token"
+  , settingsEnvironment = Environment "test"
+  , settingsRevision = Nothing
+  , settingsRequestModifiers = defaultRequestModifiers
+  }
 
 withApp
   :: (IORef (Maybe Item) -> W.Port -> IO a)

--- a/rollbar-wai/test/Rollbar/WaiSpec.hs
+++ b/rollbar-wai/test/Rollbar/WaiSpec.hs
@@ -11,42 +11,43 @@ import qualified Network.Wai as W
 import qualified Network.Wai.Handler.Warp as W
 
 import Control.Concurrent (threadDelay)
-import Control.Monad (join)
+import Control.Concurrent.MVar
+import Control.Monad (void)
 import Control.Monad.IO.Class
 import Data.Aeson
-import Data.IORef
 import Network.HTTP.Req
 import Network.HTTP.Types (status200, status404)
 import Rollbar.Client
 import Rollbar.Wai (rollbarOnExceptionWith)
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
-spec = before getSettingsAndItemRef $
+spec = before getSettingsAndItemVar $
   describe "rollbarOnExceptionWith" $ do
     context "when the response status code is 200" $
       it "does not trigger a call to Rollbar" $
-        withApp $ \itemRef warpPort -> do
+        withApp $ \itemVar warpPort -> do
           let url = http "localhost" /: "success"
           response <- runReq
             defaultHttpConfig
             (req GET url NoReqBody bsResponse $ port warpPort)
           responseStatusCode response `shouldBe` 200
           responseBody response `shouldBe` "OK"
-          threadDelay 500
-          readIORef itemRef `shouldReturn` Nothing
+          threadDelay 100000
+          tryReadMVar itemVar `shouldReturn` Nothing
 
     context "when the response status code is not 200" $
       it "triggers a call to Rollbar" $
-        withApp $ \itemRef warpPort -> do
+        withApp $ \itemVar warpPort -> do
           let url = http "localhost" /: "error"
           response <- fmap responseBody $ runReq
             (defaultHttpConfig { httpConfigCheckResponse = \_ _ _ -> Nothing })
             (req GET url NoReqBody bsResponse $ port warpPort)
           response `shouldBe` "Something went wrong"
-          threadDelay 500
+          item <- timeout 5000000 $ readMVar itemVar
           let portAsText = T.pack $ show warpPort
-          join . fmap itemRequest <$> readIORef itemRef `shouldReturn` Just
+          (item >>= itemRequest) `shouldBe` Just
             ( Request
                 { requestUrl = "http://localhost:" <> portAsText <> "/error"
                 , requestMethod = "GET"
@@ -64,10 +65,10 @@ spec = before getSettingsAndItemRef $
             )
 
 
-getSettingsAndItemRef :: IO (Settings, IORef (Maybe Item))
-getSettingsAndItemRef =
+getSettingsAndItemVar :: IO (Settings, MVar Item)
+getSettingsAndItemVar =
   (,) <$> pure testSettings
-      <*> newIORef Nothing
+      <*> newEmptyMVar
 
 -- | These specs never call the Rollbar API, so any token works.
 testSettings :: Settings
@@ -79,14 +80,14 @@ testSettings = Settings
   }
 
 withApp
-  :: (IORef (Maybe Item) -> W.Port -> IO a)
-  -> (Settings, IORef (Maybe Item))
+  :: (MVar Item -> W.Port -> IO a)
+  -> (Settings, MVar Item)
   -> IO a
-withApp f (settings, itemRef) = do
+withApp f (settings, itemVar) = do
   let waiSettings = W.setOnException
-        (rollbarOnExceptionWith (createItemFake itemRef) settings)
+        (rollbarOnExceptionWith (createItemFake itemVar) settings)
         W.defaultSettings
-  W.withApplicationSettings waiSettings (return app) $ f itemRef
+  W.withApplicationSettings waiSettings (return app) $ f itemVar
 
 app :: W.Application
 app wrequest respond =
@@ -95,8 +96,11 @@ app wrequest respond =
     "/success" -> respond $ W.responseLBS status200 [] "OK"
     _ -> respond $ W.responseLBS status404 [] "Not Found"
 
-createItemFake :: IORef (Maybe Item) -> Item -> Rollbar ()
-createItemFake itemRef item = do
+-- | Hands the first reported 'Item' to the test instead of calling the API;
+-- warp may report more than one exception per connection, so later ones are
+-- ignored rather than overwriting it.
+createItemFake :: MVar Item -> Item -> Rollbar ()
+createItemFake itemVar item = do
   requestModifier <- getRequestModifier
-  liftIO $ writeIORef itemRef $ Just $
+  void $ liftIO $ tryPutMVar itemVar $
     item { itemRequest = requestModifier <$> itemRequest item }

--- a/rollbar-yesod/test/Rollbar/YesodSpec.hs
+++ b/rollbar-yesod/test/Rollbar/YesodSpec.hs
@@ -76,5 +76,13 @@ withApp = before $ do
   return (app, id)
   where
     getApp =
-      App <$> readSettings "rollbar.yaml"
-          <*> newIORef Nothing
+      App testSettings <$> newIORef Nothing
+
+-- | These specs never call the Rollbar API, so any token works.
+testSettings :: Settings
+testSettings = Settings
+  { settingsToken = Token "invalid-token"
+  , settingsEnvironment = Environment "test"
+  , settingsRevision = Nothing
+  , settingsRequestModifiers = defaultRequestModifiers
+  }


### PR DESCRIPTION
## Summary

CI currently fails on every branch because the Rollbar account behind the `ROLLBAR_TOKEN` secret has been deactivated ("This account has been deactivated. To reactivate it, log in to Rollbar and choose a plan."), and the rollbar-client suite runs `ping`/`createItem`/`reportDeploy` against the real API. This PR makes CI independent of that account, as discussed in #open-source:

- **rollbar-client**: the live-API specs are extracted into `liveApiSpecs` and marked **pending** when `ROLLBAR_TOKEN` is unset or empty; with a token set they run exactly as before. They're contract checks (Rollbar accepted the payload, the response parsed) rather than logic coverage, so skipping them doesn't lose unit coverage.
- **rollbar-wai / rollbar-yesod**: their specs never call the API but read the token via `rollbar.yaml` anyway, which made them crash without the env var; they now build `Settings` inline (same pattern ClientSpec already used), so the entire test suite runs with no Rollbar credentials.
- **workflow**: keeps passing `${{ secrets.ROLLBAR_TOKEN }}` unconditionally — a missing secret renders as an empty string, which the suite treats as "skip". Enabling/disabling the live specs is therefore pure secret management; the workflow never needs editing again.

## One admin action required

The stale `ROLLBAR_TOKEN` secret must be **deleted** (Settings → Secrets → Actions) for the skip to kick in — while it exists, the live specs still run against the deactivated account and fail. When a new Rollbar account is created, setting the secret to its `post_server_item` token re-enables the contract checks with no code changes.

## Verified

On GHC 9.8.4: `cabal test all` with `ROLLBAR_TOKEN` unset → all four suites pass, client reports `1 pending (ROLLBAR_TOKEN is not set)`; with a token set, the live specs run (verified via the `ping` spec).

Unblocks #99 once merged (it will need a rebase/merge from main). Getting a new free Rollbar account to re-enable the contract checks is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)